### PR TITLE
END and HOME are different on xterm-based terminals

### DIFF
--- a/tui_editor/tty_helpers.py
+++ b/tui_editor/tty_helpers.py
@@ -176,4 +176,7 @@ KEYMAP = {
     b"\r": KEY_ENTER,
     b"\x7f": KEY_BACKSPACE,
     b"\x1b[3~": KEY_DELETE,
+    # xterm specific keymap entries
+    b'\x1b[F': KEY_END,
+    b'\x1b[H': KEY_HOME,
 }

--- a/tui_editor/tty_helpers.py
+++ b/tui_editor/tty_helpers.py
@@ -177,6 +177,6 @@ KEYMAP = {
     b"\x7f": KEY_BACKSPACE,
     b"\x1b[3~": KEY_DELETE,
     # xterm specific keymap entries
-    b'\x1b[F': KEY_END,
-    b'\x1b[H': KEY_HOME,
+    b"\x1b[F": KEY_END,
+    b"\x1b[H": KEY_HOME,
 }


### PR DESCRIPTION
This tiny PR makes all the keys work on XTerm based terminals (GNOME Terminal and Konsole are both `xterm-256color` compatible terminals).

Fix #3.
